### PR TITLE
small change that allows the plugin to be run with php < 5.6

### DIFF
--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -29,7 +29,7 @@ class OAuthComponent extends Component
      * @var array
      */
     protected $_defaultConfig = [
-        'tokenTTL' => 30 * 24 * 60 * 60, //TTL in seconds
+        'tokenTTL' => 2592000, //TTL 30 * 24 * 60 * 60 in seconds
         'supportedGrants' => ['AuthCode', 'RefreshToken', 'ClientCredentials']
     ];
 


### PR DESCRIPTION
Using functions when instantiating properties seems to be not possible in php < 5.6. This small change makes oauth-server compatible with lower php versions (tested on php 5.5)