### PR TITLE
configured routing to recognize json extension

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,5 +1,6 @@
 <?php
 \Cake\Routing\Router::plugin('OAuthServer', ['path' => '/oauth'], function(\Cake\Routing\RouteBuilder $routes) {
+    $routes->extensions(['json']);
     $routes->connect(
         '/',
         [


### PR DESCRIPTION
I seems to be necessary to configure the json-extension in the routes.php of the plugin, even if you have it configured in the routes.php of your app. Otherwise this route: `/oauth/access_token.json` will not be recognized.