### PR TITLE
Cakephp3 header format

### DIFF
--- a/src/Auth/OAuthAuthenticate.php
+++ b/src/Auth/OAuthAuthenticate.php
@@ -78,7 +78,20 @@ class OAuthAuthenticate extends BaseAuthenticate
         }
         if (isset($this->_exception)) {
             $response->statusCode($this->_exception->httpStatusCode);
-            $response->header($this->_exception->getHttpHeaders());
+            
+            //add : to http code for cakephp (header method in Network/Respone expects header separated with double dot notation)
+            $headers = $this->_exception->getHttpHeaders();
+            $code = (string)$this->_exception->httpStatusCode;
+            $headers = array_map( function($header)use($code){
+            	$pos = strpos($header, $code);
+            	if( $pos !== -1 ){
+            		return substr($header, 0, $pos + strlen($code) ).':'.substr($header,$pos+strlen($code)+1);
+            	}
+            	return $header;
+            },
+            $headers);
+            $response->header($headers);
+            
             $response->body(
                 json_encode(
                     [


### PR DESCRIPTION
Cakephp3 accepts header in different notation than the oAuth2 package (league/oauth2-server).
HTTP/1.1 400 Bad Request
should be
HTTP/1.1 400: Bad Request
in Cakephp3 in order not to cause an error in the header method of Network/Respone.