### PR TITLE
BelongsTo relation between clients and sessions

### DIFF
--- a/src/Model/Table/SessionsTable.php
+++ b/src/Model/Table/SessionsTable.php
@@ -32,6 +32,10 @@ class SessionsTable extends Table
                 'foreignKey' => 'session_id',
                 'dependant' => true
             ]);
+        $this->belongsTo('Clients', [
+                'className' => 'OAuthServer.Clients',
+                'foreignKey' => 'client_id'
+            ]);    
         parent::initialize($config);
     }
 }


### PR DESCRIPTION
Added belongsTo relation to from client storage to sessions and corrected query in sessions (to avoid ambiguous id).
This relation is needed to make the command $this->Auth->getAuthenticate('OAuthServer.OAuth')->Server->getAccessToken()->getSession()->getClient() working which is described on http://oauth2.thephpleague.com/resource-server/securing-your-api/