### PR TITLE
Fixing integrity constraint violation for 'id'

### DIFF
--- a/src/Model/Storage/ClientStorage.php
+++ b/src/Model/Storage/ClientStorage.php
@@ -57,7 +57,7 @@ class ClientStorage extends AbstractStorage implements ClientInterface
         $result = $this->Sessions->find()
             ->contain(['Clients'])
             ->where([
-                'id' => $session->getId()
+                'Sessions.id' => $session->getId()
             ])
             ->first();
 


### PR DESCRIPTION
If you have an Id in the Sessions table and in the Clients table, it is necessary to specify which id column should be used (Error: Integrity constraint violation: 1052 Column \u0027id\u0027 in where clause is ambiguous")