### PR TITLE
accesstoken is called oauth_token in the database

### DIFF
--- a/src/Model/Storage/RefreshTokenStorage.php
+++ b/src/Model/Storage/RefreshTokenStorage.php
@@ -25,7 +25,7 @@ class RefreshTokenStorage extends AbstractStorage implements RefreshTokenInterfa
         if ($result) {
             $token = (new RefreshTokenEntity($this->server))->setId($result->refresh_token)
                 ->setExpireTime($result->expires)
-                ->setAccessTokenId($result->access_token);
+                ->setAccessTokenId($result->oauth_token);
 
             return $token;
         }


### PR DESCRIPTION
Fixed the refreshToken process: access_token is called oauth_token in the database, therefore access it through: ->oauth_token