### PR TITLE
Added option to change class names for storages and resource/authorize server

### DIFF
--- a/src/Traits/GetStorageTrait.php
+++ b/src/Traits/GetStorageTrait.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace OAuthServer\Traits;
+
+use Cake\Core\App;
+use Cake\Core\Exception\Exception;
+
+trait GetStorageTrait
+{
+    protected function _resolveClassName($class)
+    {
+        $className = App::className($class, 'Model/Storage', 'Storage');
+        if (!$className) {
+            throw new Exception(sprintf('Storage class "%s" was not found.', $class));
+        }
+        return $className;
+    }
+
+    protected function _getStorage($name)
+    {
+        $config = $this->config('storages.' . $name);
+
+        if (empty($config)) {
+            throw new Exception(sprintf('Storage class "%s" has no configuration', $name));
+        }
+
+        $className = $this->_resolveClassName($config['className']);
+        return new $className();
+    }
+}

--- a/src/Traits/GetStorageTrait.php
+++ b/src/Traits/GetStorageTrait.php
@@ -7,6 +7,13 @@ use Cake\Core\Exception\Exception;
 
 trait GetStorageTrait
 {
+    /**
+     * Resolve a storage class name.
+     *
+     * @param string $class Partial class name to resolve.
+     * @return string The resolved class name.
+     * @throws \Cake\Core\Exception\Exception
+     */
     protected function _resolveClassName($class)
     {
         $className = App::className($class, 'Model/Storage', 'Storage');
@@ -16,6 +23,13 @@ trait GetStorageTrait
         return $className;
     }
 
+    /**
+     * Gets the instance of a storage class by name.
+     *
+     * @param string $name Storage name.
+     * @return \League\OAuth2\Server\Storage\AbstractStorage
+     * @throws \Cake\Core\Exception\Exception
+     */
     protected function _getStorage($name)
     {
         $config = $this->config('storages.' . $name);


### PR DESCRIPTION
Now you can change the class names for storages in OAuthAuthenticate and OAuthComponent by supplying a config array formated like this:

```
[
    'storages' => [
        'scope' => [
            'className' => '...'
        ]
    ]
]
```

Additionally changing the resource and authorize server is possible:

```
[
    'resourceServer' => [
          'className' => '...'
     ]
]
```

```
[
    'authorizationServer' => [
          'className' => '...'
     ]
]
```

The advantage is that users can swap easily the storage implementation with their own one.