### PR TITLE
Avoid displaying approval screen if the client was already approved

### DIFF
--- a/src/Action/LoginAction.php
+++ b/src/Action/LoginAction.php
@@ -71,7 +71,7 @@ class LoginAction extends BaseAction
         $this->setFlash('success', $subject);
 
         $redirectUri = $this->_controller()->Auth->redirectUrl();
-        if ($this->_request()->query['redir'] == "oauth") {
+        if ($this->_request()->query('redir') == "oauth") {
             $redirectUri = [
                 'plugin' => 'OAuthServer',
                 'controller' => 'OAuth',


### PR DESCRIPTION
This fixes #32 