### PR TITLE
Removed hardcoded dependency on App\Controller\AppController

### DIFF
--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+
+use Cake\Core\Configure;
+
+/**
+ * OAuthServer plugin creates controller that extends App\Controller\AppController class.
+ * Config OAuthServer.appController allows to override the base controller class.
+ */
+$appControllerReal = Configure::read('OAuthServer.appController') ?: 'App\Controller\AppController';
+$appControllerAlias = 'OAuthServer\Controller\AppController';
+class_alias($appControllerReal, $appControllerAlias);

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -1,7 +1,6 @@
 <?php
 namespace OAuthServer\Controller;
 
-use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -9,6 +8,10 @@ use Cake\I18n\Time;
 use League\OAuth2\Server\Exception\AccessDeniedException;
 use League\OAuth2\Server\Exception\OAuthException;
 use League\OAuth2\Server\Util\RedirectUri;
+
+$appControllerReal = Configure::read('OAuthServer.appController') ?: 'App\Controller\AppController';
+$appControllerAlias = 'OAuthServer\Controller\AppController';
+class_alias($appControllerReal, $appControllerAlias);
 
 /**
  * Class OAuthController

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -9,10 +9,6 @@ use League\OAuth2\Server\Exception\AccessDeniedException;
 use League\OAuth2\Server\Exception\OAuthException;
 use League\OAuth2\Server\Util\RedirectUri;
 
-$appControllerReal = Configure::read('OAuthServer.appController') ?: 'App\Controller\AppController';
-$appControllerAlias = 'OAuthServer\Controller\AppController';
-class_alias($appControllerReal, $appControllerAlias);
-
 /**
  * Class OAuthController
  *

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OAuthServer\Test\TestCase\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use OAuthServer\Controller\OAuthController;
+
+class TestAppController extends Controller
+{
+}
+
+Configure::write('OAuthServer.appController', TestAppController::class);
+
+class OAuthControllerTest extends TestCase
+{
+    public function testInstanceOfClassFromConfig()
+    {
+        $controller = new OAuthController();
+        $this->assertInstanceOf(TestAppController::class, $controller);
+    }
+}

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -2,16 +2,9 @@
 
 namespace OAuthServer\Test\TestCase\Controller;
 
-use Cake\Controller\Controller;
-use Cake\Core\Configure;
 use Cake\TestSuite\TestCase;
 use OAuthServer\Controller\OAuthController;
-
-class TestAppController extends Controller
-{
-}
-
-Configure::write('OAuthServer.appController', TestAppController::class);
+use TestApp\Controller\TestAppController;
 
 class OAuthControllerTest extends TestCase
 {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,8 +19,13 @@ chdir($root);
 require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
 define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
-define('APP', ROOT . 'App' . DS);
+define('APP', ROOT);
 define('TMP', sys_get_temp_dir() . DS);
+
+$loader = new \Cake\Core\ClassLoader;
+$loader->register();
+$loader->addNamespace('TestApp', APP);
+
 Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'App',
@@ -49,7 +54,13 @@ if (!getenv('db_dsn')) {
 if (!getenv('DB')) {
     putenv('DB=sqlite');
 }
+
 ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
+
+Configure::write('OAuthServer.appController', 'TestApp\Controller\TestAppController');
+
+require_once $root . DS . 'config' . DS . 'bootstrap.php';
+
 Plugin::load('OAuth', [
     'path' => dirname(dirname(__FILE__)) . DS,
 ]);

--- a/tests/test_app/Controller/TestAppController.php
+++ b/tests/test_app/Controller/TestAppController.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace TestApp\Controller;
+
+use Cake\Controller\Controller;
+
+class TestAppController extends Controller
+{
+
+}


### PR DESCRIPTION
Should be perfectly backwards compatible (not tested though).

Usage, in `app.php`:
```php
'OAuthServer' => [
    'appController' => 'MyApp\Controller\AppController'
]
````