### PR TITLE
Removed hardcoded login route

### DIFF
--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -109,27 +109,4 @@ class OAuthComponent extends Component
 
         $this->Server = $server;
     }
-
-    /**
-     * @param string $authGrant Grant type
-     * @return bool|\Cake\Network\Response|void
-     */
-    public function checkAuthParams($authGrant)
-    {
-        $controller = $this->_registry->getController();
-        try {
-            return $this->Server->getGrantType($authGrant)->checkAuthorizeParams();
-        } catch (\OAuthException $e) {
-            if ($e->shouldRedirect()) {
-                return $controller->redirect($e->getRedirectUri());
-            }
-
-            $controller->RequestHandler->renderAs($this, 'json');
-            $controller->response->statusCode($e->httpStatusCode);
-            $controller->response->header($e->getHttpHeaders());
-            $controller->set('response', $e);
-            
-            return false;
-        }
-    }
 }

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -48,28 +48,10 @@ class OAuthController extends AppController
      */
     public function oauth()
     {
-        if ($this->OAuth->checkAuthParams('authorization_code')) {
-            if (!$this->Auth->user()) {
-                $query = $this->request->query;
-                $query['redir'] = 'oauth';
-
-                $this->redirect(
-                    [
-                        'plugin' => false,
-                        'controller' => 'Users',
-                        'action' => 'login',
-                        '?' => $query
-                    ]
-                );
-            } else {
-                $this->redirect(
-                    [
-                        'action' => 'authorize',
-                        '?' => $this->request->query
-                    ]
-                );
-            }
-        }
+        $this->redirect([
+            'action' => 'authorize',
+            '?' => $this->request->query
+        ], 301);
     }
 
     /**

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -1,7 +1,6 @@
 <?php
 namespace OAuthServer\Controller;
 
-use App\Controller\AppController;
 use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
@@ -9,6 +8,10 @@ use Cake\I18n\Time;
 use League\OAuth2\Server\Exception\AccessDeniedException;
 use League\OAuth2\Server\Exception\OAuthException;
 use League\OAuth2\Server\Util\RedirectUri;
+
+$appControllerReal = Configure::read('OAuthServer.appController') ?: 'App\Controller\AppController';
+$appControllerAlias = 'OAuthServer\Controller\AppController';
+class_alias($appControllerReal, $appControllerAlias);
 
 /**
  * Class OAuthController

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -5,8 +5,10 @@ use Cake\Core\Configure;
 use Cake\Event\Event;
 use Cake\Event\EventManager;
 use Cake\I18n\Time;
+use Cake\Network\Exception\HttpException;
 use League\OAuth2\Server\Exception\AccessDeniedException;
 use League\OAuth2\Server\Exception\OAuthException;
+use League\OAuth2\Server\Grant\AuthCodeGrant;
 use League\OAuth2\Server\Util\RedirectUri;
 
 $appControllerReal = Configure::read('OAuthServer.appController') ?: 'App\Controller\AppController';
@@ -25,9 +27,14 @@ class OAuthController extends AppController
      */
     public function initialize()
     {
+        parent::initialize();
+
+        if (!$this->components()->has('Auth')) {
+            throw new \RuntimeException("OAuthServer requires Auth component to be loaded and properly configured");
+        }
+
         $this->loadComponent('OAuthServer.OAuth', (array)Configure::read('OAuth'));
         $this->loadComponent('RequestHandler');
-        parent::initialize();
     }
 
     /**
@@ -36,11 +43,9 @@ class OAuthController extends AppController
      */
     public function beforeFilter(Event $event)
     {
-        if ($this->Auth) {
-            $this->Auth->allow(['oauth', 'authorize', 'accessToken']);
-        }
-
         parent::beforeFilter($event);
+
+        $this->Auth->allow(['oauth', 'authorize', 'accessToken']);
     }
 
     /**
@@ -56,43 +61,40 @@ class OAuthController extends AppController
     }
 
     /**
-     * @return \Cake\Network\Response|void
      * @throws \League\OAuth2\Server\Exception\InvalidGrantException
      */
     public function authorize()
     {
-        if (!$authParams = $this->OAuth->checkAuthParams('authorization_code')) {
-            return;
+        try {
+            /** @var AuthCodeGrant $authCodeGrant */
+            $authCodeGrant = $this->OAuth->Server->getGrantType('authorization_code');
+            $authParams = $authCodeGrant->checkAuthorizeParams();
+        } catch (OAuthException $e) {
+            // TODO ignoring $e->getHttpHeaders() for now
+            // it only sends add WWW-Authenticate header in case of InvalidClientException
+            throw new HttpException($e->getMessage(), $e->httpStatusCode, $e);
+        }
+
+        if (!$this->Auth->user()) {
+            $this->Auth->redirectUrl($this->request->here(false));
+            return $this->redirect($this->Auth->config('loginAction'));
         }
 
         $ownerModel = $this->request->query('owner_model') ?: 'Users';
         $ownerId = $this->request->query('owner_id') ?: $this->Auth->user('id');
         $clientId = $this->request->query('client_id');
-        if (!$this->Auth->user()) {
-            $query = $this->request->query;
-            $query['redir'] = 'oauth';
 
-            return $this->redirect(
-                [
-                    'plugin' => false,
-                    'controller' => 'Users',
-                    'action' => 'login',
-                    '?' => $query
-                ]
-            );
-        } else {
-            $currentTokens = $this->loadModel('OAuthServer.AccessTokens')
-                ->find()
-                ->where(['expires > ' => Time::now()->getTimestamp()])
-                ->matching('Sessions', function ($q) use ($ownerModel, $ownerId, $clientId) {
-                    return $q->where([
-                        'owner_model' => $ownerModel,
-                        'owner_id' => $ownerId,
-                        'client_id' => $clientId
-                    ]);
-                })
-                ->count();
-        }
+        $currentTokens = $this->loadModel('OAuthServer.AccessTokens')
+            ->find()
+            ->where(['expires > ' => Time::now()->getTimestamp()])
+            ->matching('Sessions', function ($q) use ($ownerModel, $ownerId, $clientId) {
+                return $q->where([
+                    'owner_model' => $ownerModel,
+                    'owner_id' => $ownerId,
+                    'client_id' => $clientId
+                ]);
+            })
+            ->count();
 
         $event = new Event('OAuthServer.beforeAuthorize', $this);
         EventManager::instance()->dispatch($event);
@@ -129,6 +131,8 @@ class OAuthController extends AppController
         $this->set('authParams', $authParams);
         $this->set('user', $this->Auth->user());
         $this->set('_serialize', array_merge(['user', 'authParams'], $serializeKeys));
+
+        return null;
     }
 
     /**

--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -50,6 +50,7 @@ class OAuthController extends AppController
     {
         $this->redirect([
             'action' => 'authorize',
+            '_ext' => $this->request->param('_ext'),
             '?' => $this->request->query
         ], 301);
     }

--- a/tests/Fixture/ClientsFixture.php
+++ b/tests/Fixture/ClientsFixture.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * @copyright Martinus.sk
+ * @author Jan Sukenik
+ * @since 13. 2. 2017
+ */
+
+namespace OAuthServer\Test\Fixture;
+
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class ClientsFixture extends TestFixture
+{
+    public $table = 'oauth_clients';
+    public $fields = [
+        'id' => ['type' => 'string'],
+        'client_secret' => ['type' => 'string'],
+        'name' => ['type' => 'string'],
+        'redirect_uri' => ['type' => 'string'],
+        'parent_model' => ['type' => 'string'],
+        'parent_id' => ['type' => 'integer'],
+    ];
+
+    public $records = [
+        [
+            'id' => 'TEST',
+            'client_secret' => 'TestSecret',
+            'name' => 'Test',
+            'redirect_uri' => 'http://www.example.com',
+        ]
+    ];
+}

--- a/tests/Fixture/ScopesFixture.php
+++ b/tests/Fixture/ScopesFixture.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * @copyright Martinus.sk
+ * @author Jan Sukenik
+ * @since 13. 2. 2017
+ */
+
+namespace OAuthServer\Test\Fixture;
+
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+class ScopesFixture extends TestFixture
+{
+    public $table = 'oauth_scopes';
+    public $fields = [
+        'id' => ['type' => 'string'],
+        'description' => ['type' => 'string'],
+    ];
+
+    public $records = [
+        ['id' => 'test', 'description' => '']
+    ];
+}

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace OAuthServer\Test\TestCase\Controller;
+
+use Cake\Controller\Controller;
+use Cake\Core\Configure;
+use Cake\TestSuite\TestCase;
+use OAuthServer\Controller\OAuthController;
+
+class TestAppController extends Controller
+{
+}
+
+Configure::write('OAuthServer.appController', TestAppController::class);
+
+class OAuthControllerTest extends TestCase
+{
+    public function testInstanceOfClassFromConfig()
+    {
+        $controller = new OAuthController();
+        $this->assertInstanceOf(TestAppController::class, $controller);
+    }
+}

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -4,6 +4,7 @@ namespace OAuthServer\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
+use Cake\Routing\RouteBuilder;
 use Cake\Routing\Router;
 use Cake\TestSuite\IntegrationTestCase;
 use OAuthServer\Controller\OAuthController;
@@ -25,12 +26,22 @@ Configure::write('OAuthServer.appController', TestAppController::class);
 
 class OAuthControllerTest extends IntegrationTestCase
 {
+    public $fixtures = [
+        'plugin.o_auth_server.clients',
+        'plugin.o_auth_server.scopes'
+    ];
+
     public function setUp()
     {
         // class Router needs to be loaded in order for TestCase to automatically include routes
         // not really sure how to do it properly, this hotfix seems good enough
         Router::defaultRouteClass();
+
         parent::setUp();
+
+        Router::plugin('OAuthServer', function (RouteBuilder $routes) {
+            $routes->connect('/login', ['controller' => 'Users', 'action' => 'login']);
+        });
     }
 
     public function testInstanceOfClassFromConfig()
@@ -52,8 +63,33 @@ class OAuthControllerTest extends IntegrationTestCase
      */
     public function testOauthRedirectsToAuthorize($ext)
     {
-        $extension = $ext ? ".$ext" : '';
-        $this->get("/oauth$extension?client_id=CID&anything=at_all");
+        $this->get($this->url("/oauth", $ext) . "?client_id=CID&anything=at_all");
         $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '_ext' => $ext, '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
+    }
+
+    /**
+     * @dataProvider extensions
+     */
+    public function testAuthorizeInvalidParams($ext)
+    {
+        $_GET = ['client_id' => 'INVALID', 'redirect_uri' => 'http://www.example.com', 'response_type' => 'code', 'scope' => 'test'];
+        $this->get($this->url('/oauth/authorize', $ext) . '?' . http_build_query($_GET));
+        $this->assertResponseError();
+    }
+
+    /**
+     * @dataProvider extensions
+     */
+    public function testAuthorizeLoginRedirect($ext)
+    {
+        $_GET = ['client_id' => 'TEST', 'redirect_uri' => 'http://www.example.com', 'response_type' => 'code', 'scope' => 'test'];
+        $this->get($this->url('/oauth/authorize', $ext) . '?' . http_build_query($_GET));
+        $this->assertRedirect(['controller' => 'Users', 'action' => 'login']);
+    }
+
+    private function url($path, $ext)
+    {
+        $ext = $ext ? ".$ext" : '';
+        return $path . $ext;
     }
 }

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -4,20 +4,44 @@ namespace OAuthServer\Test\TestCase\Controller;
 
 use Cake\Controller\Controller;
 use Cake\Core\Configure;
-use Cake\TestSuite\TestCase;
+use Cake\Routing\Router;
+use Cake\TestSuite\IntegrationTestCase;
 use OAuthServer\Controller\OAuthController;
 
 class TestAppController extends Controller
 {
+    public function initialize()
+    {
+        $this->loadComponent('Auth', [
+            'loginAction' => [
+                'controller' => 'Users',
+                'action' => 'login',
+            ]
+        ]);
+    }
 }
 
 Configure::write('OAuthServer.appController', TestAppController::class);
 
-class OAuthControllerTest extends TestCase
+class OAuthControllerTest extends IntegrationTestCase
 {
+    public function setUp()
+    {
+        // class Router needs to be loaded in order for TestCase to automatically include routes
+        // not really sure how to do it properly, this hotfix seems good enough
+        Router::defaultRouteClass();
+        parent::setUp();
+    }
+
     public function testInstanceOfClassFromConfig()
     {
         $controller = new OAuthController();
         $this->assertInstanceOf(TestAppController::class, $controller);
+    }
+
+    public function testOauthRedirectsToAuthorize()
+    {
+        $this->get('/oauth?client_id=CID&anything=at_all');
+        $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
     }
 }

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -39,9 +39,21 @@ class OAuthControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(TestAppController::class, $controller);
     }
 
-    public function testOauthRedirectsToAuthorize()
+    public function extensions()
     {
-        $this->get('/oauth?client_id=CID&anything=at_all');
-        $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
+        return [
+            [null],
+            ['json']
+        ];
+    }
+
+    /**
+     * @dataProvider extensions
+     */
+    public function testOauthRedirectsToAuthorize($ext)
+    {
+        $extension = $ext ? ".$ext" : '';
+        $this->get("/oauth$extension?client_id=CID&anything=at_all");
+        $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '_ext' => $ext, '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -21,6 +21,7 @@ require_once 'vendor/autoload.php';
 define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
 define('APP', ROOT . 'App' . DS);
 define('TMP', sys_get_temp_dir() . DS);
+define('CONFIG', $root . DS . 'config' . DS);
 Configure::write('debug', true);
 Configure::write('App', [
     'namespace' => 'App',
@@ -53,3 +54,6 @@ ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
 Plugin::load('OAuth', [
     'path' => dirname(dirname(__FILE__)) . DS,
 ]);
+
+\Cake\Routing\DispatcherFactory::add('Routing');
+\Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,7 +19,7 @@ chdir($root);
 require_once 'vendor/cakephp/cakephp/src/basics.php';
 require_once 'vendor/autoload.php';
 define('ROOT', $root . DS . 'tests' . DS . 'test_app' . DS);
-define('APP', ROOT . 'App' . DS);
+define('APP', ROOT);
 define('TMP', sys_get_temp_dir() . DS);
 define('CONFIG', $root . DS . 'config' . DS);
 Configure::write('debug', true);
@@ -27,7 +27,7 @@ Configure::write('App', [
     'namespace' => 'App',
     'paths' => [
         'plugins' => [ROOT . 'Plugin' . DS],
-        'templates' => [ROOT . 'App' . DS . 'Template' . DS]
+        'templates' => [ROOT . 'Template' . DS]
     ]
 ]);
 Cake\Cache\Cache::config([
@@ -54,6 +54,7 @@ ConnectionManager::config('test', ['url' => getenv('db_dsn')]);
 Plugin::load('OAuth', [
     'path' => dirname(dirname(__FILE__)) . DS,
 ]);
+Plugin::load('OAuthServer', ['path' => $root]);
 
 \Cake\Routing\DispatcherFactory::add('Routing');
 \Cake\Routing\DispatcherFactory::add('ControllerFactory');

--- a/tests/test_app/Template/Layout/error.ctp
+++ b/tests/test_app/Template/Layout/error.ctp
@@ -1,0 +1,1 @@
+Error page


### PR DESCRIPTION
(these pull requests depend on each other, so they always contain all the stuff from previous ones)

In this one, I removed hardcoded login route and rely on Auth plugin configuration. 

Also, by using default Auth plugin behavior, (1) we don't have to pass all the oauth parameters (client_id, etc.) to login action and back (they are kept in session) and (2) we can also remove the `if ($this->request->query['redir'] === 'oauth') ...` part from app's login action - which makes the plugin just simpler to use :-)

Last but not least, I removed `OAuthComponent::checkAuthParams` method:
1. after putting redirect in `oauth` action, it was now only used once in the entire plugin
2. it was catching `\OAuthException` 
    - whitch is something from PECL oauth library and PHP League's implementation does not use it 
    - the whole catch was basically a dead code and cake's default error handling was used 
    - default error handling is now still being used, which I personally like, the change ensures that correct http status code is sent