### PR TITLE
Added support for configuring grant types

### DIFF
--- a/src/Controller/Component/OAuthComponent.php
+++ b/src/Controller/Component/OAuthComponent.php
@@ -4,7 +4,7 @@ namespace OAuthServer\Controller\Component;
 use Cake\Controller\Component;
 use Cake\Core\App;
 use Cake\Network\Exception\NotImplementedException;
-use OAuthServer\Model\Storage;
+use Cake\Utility\Inflector;
 use OAuthServer\Traits\GetStorageTrait;
 
 class OAuthComponent extends Component
@@ -27,7 +27,6 @@ class OAuthComponent extends Component
      * @var array
      */
     protected $_defaultConfig = [
-        'tokenTTL' => 2592000, //TTL 30 * 24 * 60 * 60 in seconds
         'supportedGrants' => ['AuthCode', 'RefreshToken', 'ClientCredentials', 'Password'],
         'storages' => [
             'session' => [
@@ -80,13 +79,18 @@ class OAuthComponent extends Component
         $server->setRefreshTokenStorage($this->_getStorage('refreshToken'));
 
         $supportedGrants = isset($config['supportedGrants']) ? $config['supportedGrants'] : $this->config('supportedGrants');
-        foreach ($supportedGrants as $grant) {
+        $supportedGrants = $this->_registry->normalizeArray($supportedGrants);
+
+        foreach ($supportedGrants as $properties) {
+            $grant = $properties['class'];
+
             if (!in_array($grant, $this->_allowedGrants)) {
-                throw new NotImplementedException(__('The {0} grant type is not supported by the OAuth server'));
+                throw new NotImplementedException(__('The {0} grant type is not supported by the OAuthServer'));
             }
 
             $className = '\\League\\OAuth2\\Server\\Grant\\' . $grant . 'Grant';
             $objGrant = new $className();
+
             if ($grant === 'Password') {
                 $objGrant->setVerifyCredentialsCallback(function ($username, $password) {
                     $controller = $this->_registry->getController();
@@ -102,10 +106,20 @@ class OAuthComponent extends Component
                     }
                 });
             }
+
+            foreach ($properties['config'] as $key => $value) {
+                $method = 'set' . Inflector::camelize($key);
+                if (is_callable([$objGrant, $method])) {
+                    $objGrant->$method($value);
+                }
+            }
+
             $server->addGrantType($objGrant);
         }
 
-        $server->setAccessTokenTTL($this->config('tokenTTL'));
+        if ($this->config('accessTokenTTL')) {
+            $server->setAccessTokenTTL($this->config('accessTokenTTL'));
+        }
 
         $this->Server = $server;
     }

--- a/tests/TestCase/Controller/Component/OAuthComponentTest.php
+++ b/tests/TestCase/Controller/Component/OAuthComponentTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace OAuthServer\Test\TestCase\Controller\Component;
+
+use Cake\Controller\ComponentRegistry;
+use Cake\TestSuite\TestCase;
+use League\OAuth2\Server\Grant\RefreshTokenGrant;
+use OAuthServer\Controller\Component\OAuthComponent;
+
+class OAuthComponentTest extends TestCase
+{
+    public function testDefaultTokenTTL()
+    {
+        $component = new OAuthComponent(new ComponentRegistry(), []);
+        $this->assertEquals(3600, $component->Server->getAccessTokenTTL());
+    }
+
+    public function testConfigTokenTTL()
+    {
+        $component = new OAuthComponent(new ComponentRegistry(), [
+            'accessTokenTTL' => 5
+        ]);
+        $this->assertEquals(5, $component->Server->getAccessTokenTTL());
+    }
+
+    /**
+     * @expectedException \League\OAuth2\Server\Exception\InvalidGrantException
+     */
+    public function testGrantWhitelist()
+    {
+        $component = new OAuthComponent(new ComponentRegistry(), [
+            'supportedGrants' => ['AuthCode'],
+        ]);
+        $component->Server->getGrantType('refresh_token');
+    }
+
+    public function testGrantConfig()
+    {
+        $component = new OAuthComponent(new ComponentRegistry(), [
+            'supportedGrants' => [
+                'RefreshToken' => [
+                    'refreshTokenTTL' => 4
+                ]
+            ],
+        ]);
+
+    /** @var RefreshTokenGrant $grant */
+        $grant = $component->Server->getGrantType('refresh_token');
+        $this->assertEquals(4, $grant->getRefreshTokenTTL());
+    }
+}


### PR DESCRIPTION
Currently there is no way to configure refresh token TTL :-)

I needed to configure it because the default access token TTL was 30 days and refresh token TTL was 7 days. This is useless, since refresh token is supposed to be used after the access token expires :-)

So, my suggestion is to configure grants in `supportedGrants` config:
```php
'supportedGrants' => [
    'AuthCode',
    'RefreshToken' => [
        'refreshTokenTTL' => 24*3600
    ],
]
```

Also, since default TTLs (30 and 7 days) are mixed up, I propose to drop the 30 day config and just use PHP League's default of 1 hour.

Since we talked about breaking compatibility I'm also suggesting to rename config `tokenTTL` to `accessTokenTTL`, just to make usage more clear. We can make both names work, but I don't think it's necessary.

