### PR TITLE
Changed root config name to OAuthServer

### DIFF
--- a/src/Controller/OAuthController.php
+++ b/src/Controller/OAuthController.php
@@ -21,7 +21,7 @@ class OAuthController extends AppController
      */
     public function initialize()
     {
-        $this->loadComponent('OAuthServer.OAuth', (array)Configure::read('OAuth'));
+        $this->loadComponent('OAuthServer.OAuth', (array)Configure::read('OAuthServer'));
         $this->loadComponent('RequestHandler');
         parent::initialize();
     }


### PR DESCRIPTION
And the last backwards incompatible suggestion, use the plugin name `OAuthServer` as a root config key, instead of more ambiguous `OAuth`.