### PR TITLE
Only /access_token route needs to support json extension

### DIFF
--- a/config/routes.php
+++ b/config/routes.php
@@ -1,6 +1,5 @@
 <?php
 \Cake\Routing\Router::plugin('OAuthServer', ['path' => '/oauth'], function (\Cake\Routing\RouteBuilder $routes) {
-    $routes->extensions(['json']);
     $routes->connect(
         '/',
         [
@@ -20,6 +19,9 @@
         [
             'controller' => 'OAuth',
             'action' => 'accessToken'
+        ],
+        [
+            '_ext' => ['json']
         ]
     );
 });


### PR DESCRIPTION
I've found 1 more change, I guess I forgot about it earlier.

Basically, /oauth and /oauth/authorize actions do not need to support json extension. Actually, /oauth/authorize.json might even leak some sensitive data (if not careful), so I think that it is better to disable it completely.