### PR TITLE
 CakePHP 3.4 uses query param instead of session for login redirect

### DIFF
--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -57,8 +57,10 @@ class OAuthControllerTest extends IntegrationTestCase
     public function testAuthorizeLoginRedirect()
     {
         $_GET = ['client_id' => 'TEST', 'redirect_uri' => 'http://www.example.com', 'response_type' => 'code', 'scope' => 'test'];
-        $this->get($this->url('/oauth/authorize') . '?' . http_build_query($_GET));
-        $this->assertRedirect(['controller' => 'Users', 'action' => 'login']);
+        $authorizeUrl = $this->url('/oauth/authorize') . '?' . http_build_query($_GET);
+
+        $this->get($authorizeUrl);
+        $this->assertRedirect(['controller' => 'Users', 'action' => 'login', '?' => ['redirect' => $authorizeUrl]]);
     }
 
     public function testStoreCurrentUserAndDefaultAuth()

--- a/tests/TestCase/Controller/OAuthControllerTest.php
+++ b/tests/TestCase/Controller/OAuthControllerTest.php
@@ -41,40 +41,23 @@ class OAuthControllerTest extends IntegrationTestCase
         $this->assertInstanceOf(TestAppController::class, $controller);
     }
 
-    public function extensions()
+    public function testOauthRedirectsToAuthorize()
     {
-        return [
-            [null],
-            ['json']
-        ];
+        $this->get($this->url("/oauth") . "?client_id=CID&anything=at_all");
+        $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
     }
 
-    /**
-     * @dataProvider extensions
-     */
-    public function testOauthRedirectsToAuthorize($ext)
-    {
-        $this->get($this->url("/oauth", $ext) . "?client_id=CID&anything=at_all");
-        $this->assertRedirect(['controller' => 'OAuth', 'action' => 'authorize', '_ext' => $ext, '?' => ['client_id' => 'CID', 'anything' => 'at_all']]);
-    }
-
-    /**
-     * @dataProvider extensions
-     */
-    public function testAuthorizeInvalidParams($ext)
+    public function testAuthorizeInvalidParams()
     {
         $_GET = ['client_id' => 'INVALID', 'redirect_uri' => 'http://www.example.com', 'response_type' => 'code', 'scope' => 'test'];
-        $this->get($this->url('/oauth/authorize', $ext) . '?' . http_build_query($_GET));
+        $this->get($this->url('/oauth/authorize') . '?' . http_build_query($_GET));
         $this->assertResponseError();
     }
 
-    /**
-     * @dataProvider extensions
-     */
-    public function testAuthorizeLoginRedirect($ext)
+    public function testAuthorizeLoginRedirect()
     {
         $_GET = ['client_id' => 'TEST', 'redirect_uri' => 'http://www.example.com', 'response_type' => 'code', 'scope' => 'test'];
-        $this->get($this->url('/oauth/authorize', $ext) . '?' . http_build_query($_GET));
+        $this->get($this->url('/oauth/authorize') . '?' . http_build_query($_GET));
         $this->assertRedirect(['controller' => 'Users', 'action' => 'login']);
     }
 
@@ -112,7 +95,7 @@ class OAuthControllerTest extends IntegrationTestCase
         $this->assertTrue($sessions->exists(['owner_id' => 15, 'owner_model' => 'AnotherModel']), "Session in database was not correct");
     }
 
-    private function url($path, $ext)
+    private function url($path, $ext = null)
     {
         $ext = $ext ? ".$ext" : '';
 


### PR DESCRIPTION
Since CakePHP 3.4, query parameter is being used to store redirect URL for login, instead of session. Using AuthComponent's `redirectUrl()` to store it no longer works.

Also, to be more "Cake-ish", we should let AuthComponent handle login redirect. That is easily done by setting authorize action as denied.

OAuth spec however requires to validate OAuth params (client_id, redirect_uri, ...) before login redirect, so I moved these into beforeFilter.

Since change is using default Cake behavior, it should even be 3.3 compatible, did not test it though.